### PR TITLE
style: uniform navy background across all pages

### DIFF
--- a/app/about/page.js
+++ b/app/about/page.js
@@ -123,7 +123,7 @@ export default function AboutPage() {
       </section>
 
       {/* Chef Section */}
-      <section className="py-24 px-6 bg-noir-mid">
+      <section className="py-24 px-6">
         <div className="max-w-7xl mx-auto">
           <div className="grid lg:grid-cols-2 gap-16 items-center">
             <div className="order-2 lg:order-1">
@@ -173,7 +173,7 @@ export default function AboutPage() {
       </section>
 
       {/* Values Grid */}
-      <section className="py-24 lg:py-32 px-6 bg-noir-soft">
+      <section className="py-24 lg:py-32 px-6">
         <div className="max-w-7xl mx-auto">
           <div className="text-center mb-16">
             <p className="section-label mb-4">What We Stand For</p>

--- a/app/auth/login/page.js
+++ b/app/auth/login/page.js
@@ -125,7 +125,7 @@ export default function LoginPage() {
       </div>
 
       {/* Right — Form */}
-      <div className="flex items-center justify-center px-6 py-20 bg-noir-mid">
+      <div className="flex items-center justify-center px-6 py-20">
         <div className="w-full max-w-md">
           <div className="mb-10">
             <Link href="/" className="font-display text-2xl font-light tracking-widest text-cream hover:text-gold transition-colors">

--- a/app/auth/register/page.js
+++ b/app/auth/register/page.js
@@ -82,7 +82,7 @@ export default function RegisterPage() {
       </div>
 
       {/* Right — Form */}
-      <div className="flex items-center justify-center px-6 py-20 bg-noir-mid">
+      <div className="flex items-center justify-center px-6 py-20">
         <div className="w-full max-w-md">
           <div className="mb-10">
             <Link href="/" className="font-display text-2xl font-light tracking-widest text-cream hover:text-gold transition-colors">

--- a/app/booking/page.js
+++ b/app/booking/page.js
@@ -47,7 +47,7 @@ export default async function BookingPage() {
       </section>
 
       {/* Contact info */}
-      <section className="py-12 px-6 bg-noir-soft border-t border-white/5">
+      <section className="py-12 px-6 border-t border-white/5">
         <div className="max-w-4xl mx-auto flex flex-col md:flex-row items-center justify-between gap-6">
           <div>
             <p className="section-label mb-2">Need Help?</p>

--- a/app/menu/a-la-carte/page.js
+++ b/app/menu/a-la-carte/page.js
@@ -140,7 +140,7 @@ export default function AlaCartePage() {
       </section>
 
       {/* Menu intro + navigation */}
-      <section className="py-12 px-6 bg-noir-mid border-b border-white/5">
+      <section className="py-12 px-6 border-b border-white/5">
         <div className="max-w-5xl mx-auto">
           <p className="text-cream/40 text-sm font-light text-center max-w-2xl mx-auto mb-8 leading-relaxed">
             All our dishes are prepared fresh daily using the finest sustainable seafood and seasonal produce. Our pasta is made by hand each morning. Please inform your server of any dietary requirements.
@@ -170,7 +170,7 @@ export default function AlaCartePage() {
       </section>
 
       {/* Footnote */}
-      <section className="py-12 px-6 bg-noir-soft border-t border-white/5">
+      <section className="py-12 px-6 border-t border-white/5">
         <div className="max-w-4xl mx-auto text-center space-y-2">
           <p className="text-cream/25 text-xs font-mono-label tracking-widest uppercase">
             All prices include VAT · Optional 12.5% service charge

--- a/app/menu/dessert/page.js
+++ b/app/menu/dessert/page.js
@@ -176,7 +176,7 @@ export default function DessertPage() {
       </section>
 
       {/* Intro */}
-      <section className="py-12 px-6 bg-noir-mid border-b border-white/5">
+      <section className="py-12 px-6 border-b border-white/5">
         <div className="max-w-2xl mx-auto text-center">
           <p className="text-cream/40 text-sm font-light leading-relaxed">
             Our pastry kitchen draws on the deep traditions of Italian confectionery — from the vibrant markets of Palermo to the espresso bars of Naples. Everything is made in-house, daily, with passion.
@@ -194,7 +194,7 @@ export default function DessertPage() {
       </section>
 
       {/* Footnote */}
-      <section className="py-12 px-6 bg-noir-soft border-t border-white/5">
+      <section className="py-12 px-6 border-t border-white/5">
         <div className="max-w-4xl mx-auto text-center space-y-2">
           <p className="text-cream/25 text-xs font-mono-label tracking-widest uppercase">
             All prices include VAT · Optional 12.5% service charge

--- a/app/menu/page.js
+++ b/app/menu/page.js
@@ -91,7 +91,7 @@ export default function MenuPage() {
 
             {/* Content */}
             <div
-              className={`flex items-center px-10 lg:px-16 py-16 bg-noir-mid ${menu.align === 'right' ? 'lg:order-1' : 'lg:order-2'
+              className={`flex items-center px-10 lg:px-16 py-16 ${menu.align === 'right' ? 'lg:order-1' : 'lg:order-2'
                 }`}
             >
               <div className="max-w-md">
@@ -114,7 +114,7 @@ export default function MenuPage() {
       </section>
 
       {/* Reservation CTA */}
-      <section className="py-20 px-6 text-center bg-noir-soft border-t border-white/5">
+      <section className="py-20 px-6 text-center border-t border-white/5">
         <p className="section-label mb-4">Ready to Dine?</p>
         <h2 className="font-display text-4xl font-light text-cream mb-8">
           Reserve Your <span className="italic text-gold">Table</span>

--- a/app/menu/wine-list/page.js
+++ b/app/menu/wine-list/page.js
@@ -202,7 +202,7 @@ export default function WineListPage() {
       </section>
 
       {/* Intro */}
-      <section className="py-12 px-6 bg-noir-mid border-b border-white/5">
+      <section className="py-12 px-6 border-b border-white/5">
         <div className="max-w-2xl mx-auto text-center">
           <p className="text-cream/40 text-sm font-light leading-relaxed mb-6">
             Our wine list is a journey through Italy's most extraordinary wine regions, curated by our sommelier to complement the flavours of our kitchen. We specialise in coastal whites and medium-bodied reds that sing alongside seafood.
@@ -232,7 +232,7 @@ export default function WineListPage() {
       </section>
 
       {/* Footnote */}
-      <section className="py-12 px-6 bg-noir-soft border-t border-white/5">
+      <section className="py-12 px-6 border-t border-white/5">
         <div className="max-w-4xl mx-auto text-center space-y-2">
           <p className="text-cream/25 text-xs font-mono-label tracking-widest uppercase">
             All prices include VAT · Sommelier available on request

--- a/app/page.js
+++ b/app/page.js
@@ -113,7 +113,7 @@ export default function HomePage() {
       </section>
 
       {/* Dish Grid */}
-      <section className="py-16 px-6 bg-noir-mid">
+      <section className="py-16 px-6">
         <div className="max-w-7xl mx-auto">
           <div className="text-center mb-14">
             <p className="section-label mb-4">From Our Kitchen</p>
@@ -163,7 +163,7 @@ export default function HomePage() {
       </section>
 
       {/* Opening Hours & Map */}
-      <section className="py-24 px-6 bg-noir-soft">
+      <section className="py-24 px-6">
         <div className="max-w-7xl mx-auto">
           <div className="grid lg:grid-cols-2 gap-16">
             {/* Hours */}


### PR DESCRIPTION
Remove bg-noir-mid/soft from all page sections so they inherit the body background (#0F1C2E). Footer retains bg-noir-soft (#1C2E4A) as the only tonal distinction. Navbar dropdown, modals and form inputs keep their bg for visual differentiation.

https://claude.ai/code/session_01CeYB6s2kTAAsiJikjM5HgQ